### PR TITLE
Adding clause setting undefined columns to an empty string

### DIFF
--- a/lib/express-csv.js
+++ b/lib/express-csv.js
@@ -44,6 +44,9 @@ exports.preventCast = false;
  */
 
 function escape(field) {
+  if (field == undefined) {
+    return '';
+  }
   if (exports.preventCast) {
     return '"="' + field.toString().replace(/\"/g, '""') + '""';
   }


### PR DESCRIPTION
Previously a crash would occur if a field was undefined because toString cannot
be called on an undefined parameter.
