### PR TITLE
support serializing an array of objects

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -61,6 +61,14 @@ $ curl --verbose http://127.0.0.1:3000/
 * Closing connection #0
 ```
 
+Alternatively, you can also pass an array of objects to be serialized, in which case the object's
+properties will be iterated over.  E.g.:
+
+```js
+res.csv([ { name: "joe", id: 1 }]
+//=> "joe", 1
+```
+
 ## License
 
     The MIT License

--- a/lib/express-csv.js
+++ b/lib/express-csv.js
@@ -61,6 +61,28 @@ function escape(field) {
 }
 
 /**
+ * Convert an object to an array of property values.
+ *
+ * Example:
+ *    objToArray({ name: "john", id: 1 })
+ *    // => [ "john", 1 ]
+ *
+ * @param {Object} obj The object to convert.
+ * @return {Array} The array of object properties.
+ * @api private
+ */
+
+function objToArray(obj) {
+  var result = [];
+  for (var prop in obj) {
+    if (obj.hasOwnProperty(prop)) {
+      result.push(obj[prop]);
+    }
+  }
+  return result;
+}
+
+/**
  * Send CSV response with `obj`, optional `headers`, and optional `status`.
  * 
  * @param {Array} obj
@@ -77,6 +99,7 @@ res.csv = function(obj, headers, status) {
   this.header('Content-Type', 'text/csv');
 
   obj.forEach(function(item) {
+    if (!(item instanceof Array)) item = objToArray(item);
     body += item.map(escape).join(exports.separator) + '\r\n';
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,13 @@ app.get('/test/3', function(req, res) {
   ]);
 });
 
+app.get('/test/objectArray', function(req, res) {
+  res.csv([
+    { stringProp: "a", nullProp: null, undefinedProp: undefined },
+    { stringProp: "b", nullProp: null, undefinedProp: undefined }
+  ]);
+});
+
 app.listen(8383);
 
 describe('express-csv', function() {
@@ -53,6 +60,67 @@ describe('express-csv', function() {
 });
 
 describe('res.csv()', function() {
+
+  describe('when given an array of objects', function() {
+    describe('and ignoreNullOrUndefined is true', function() {
+      var rows;
+
+      beforeEach(function(done) {
+        csv.ignoreNullOrUndefined = true;
+        request
+          .get('http://127.0.0.1:8383/test/objectArray')
+          .end(function(res) {
+            rows = res.text.split("\r\n");
+            done();
+          });
+      });
+
+      it('should include values that exist', function() {
+        rows[0].split(",")[0].should.equal('"a"');
+        rows[1].split(",")[0].should.equal('"b"');
+      });
+
+      it('should exclude null', function() {
+        rows[0].split(",")[1].should.equal('');
+        rows[0].split(",")[2].should.equal('');
+      });
+
+      it('should exclude undefined', function() {
+        rows[0].split(",")[2].should.equal('');
+        rows[1].split(",")[2].should.equal('');
+      });
+    });
+
+    describe('and ignoreNullOrUndefined is false', function() {
+      var rows;
+
+      beforeEach(function(done) {
+        csv.ignoreNullOrUndefined = false;
+        request
+          .get('http://127.0.0.1:8383/test/objectArray')
+          .end(function(res) {
+            rows = res.text.split("\r\n");
+            done();
+          });
+      });
+
+      it('should include values that exist', function() {
+        rows[0].split(",")[0].should.equal('"a"');
+        rows[1].split(",")[0].should.equal('"b"');
+      });
+
+      it('should include null', function() {
+        rows[0].split(",")[1].should.equal('"null"');
+        rows[1].split(",")[1].should.equal('"null"');
+      });
+
+      it('should include undefined', function() {
+        rows[0].split(",")[2].should.equal('"undefined"');
+        rows[1].split(",")[2].should.equal('"undefined"');
+      });
+    });
+  });
+
   it('should response csv', function(done) {
     request 
       .get('http://127.0.0.1:8383/test/1')


### PR DESCRIPTION
It is very common to have an array of objects that you
want to serialize.  For example, many database packages
return a `rows` argument that is an array of row objects.

@nulltask let me know if you'd like to make any changes to this.  Thanks for making this package.
