### PR TITLE
Add method for all available response object to support express>=2.5.11

### DIFF
--- a/lib/express-csv.js
+++ b/lib/express-csv.js
@@ -9,8 +9,7 @@
  */
 
 var http = require('http')
-  , express = require('express')
-  , res = express.response || http.ServerResponse.prototype;
+  , express = require('express');
 
 /**
  * Import package information.
@@ -92,7 +91,7 @@ function objToArray(obj) {
  * @api public
  */
 
-res.csv = function(obj, headers, status) {
+csv = function(obj, headers, status) {
   var body = '';
 
   this.charset = this.charset || 'utf-8';
@@ -105,4 +104,13 @@ res.csv = function(obj, headers, status) {
 
   return this.send(body, headers, status);
 };
+
+/**
+ * Add method to response object
+ */
+
+if (express.response)
+  express.response.csv = csv
+if (http.ServerResponse)
+  http.ServerResponse.prototype.csv = csv
 


### PR DESCRIPTION
I didn't check express's source code or release note. It's kind of a dirty fix, but working.
