### PR TITLE
Unused csv variable deleted

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,8 +24,9 @@ Example:
 
 ```js
 var express = require('express')
-  , csv = require('express-csv')
   , app = module.exports = express.createServer();
+
+require('express-csv')
 
 app.get('/', function(req, res) {
   res.csv([


### PR DESCRIPTION
Assigning a variable `csv` to `require('express-csv') is unnecessary and throws a lint error for the unused variable that likely wont ever be used because`res.csv` is already assigned a function.

Note: using recommended .jshintrc from https://github.com/jshint/jshint/blob/master/examples/.jshintrc. 
